### PR TITLE
Compatibility code with Cmake for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,49 @@ INCLUDE_DIRECTORIES(
         ${OPENSSL_INCLUDE_DIR}
 )
 
-TARGET_LINK_LIBRARIES(
-        ${PROJECT_NAME}
-        ${Boost_LIBRARIES}
-        discordpp
+add_definitions(-DBOOST_ALL_NO_LIB)
+
+if (WIN32)
+	add_definitions(-D_WIN32_WINNT=0x0601) # Target: Windows 7
+endif()
+
+target_link_libraries(
+	${PROJECT_NAME} 
+	${Boost_LIBRARIES}
+	discordpp
         discordpp-rest-beast
         discordpp-websocket-beast
         Threads::Threads
-        crypto
-        ssl
 )
+
+target_link_libraries(
+	${PROJECT_NAME}
+	debug ${Boost_FILESYSTEM_LIBRARY_DEBUG}
+	optimized ${Boost_FILESYSTEM_LIBRARY_RELEASE} 
+)
+
+target_link_libraries(
+	${PROJECT_NAME}
+	debug ${Boost_SYSTEM_LIBRARY_DEBUG}
+	optimized ${Boost_SYSTEM_LIBRARY_RELEASE}
+)
+
+if (WIN32 AND MSVC)
+	target_link_libraries(
+		${PROJECT_NAME}
+		debug ${LIB_EAY_DEBUG} 
+		optimized ${LIB_EAY_RELEASE}
+	)
+	 
+	target_link_libraries(
+		${PROJECT_NAME}
+		debug ${SSL_EAY_DEBUG}
+		optimized ${SSL_EAY_RELEASE}
+	)
+else()
+	target_link_libraries(
+		${PROJECT_NAME}
+		${CRYPTO_LIBRARIES}
+		${OPENSSL_LIBRARIES}
+	)
+endif()


### PR DESCRIPTION
Using Cmake for Windows 3.15 and Microsoft Visual Studio 2019, echo-bot fails to correctly link Boost and OpenSSL libraries.

Changes done:
- Added manually linkage of Boost Filesystem and Boost System for both Debug and Release builds
- Fixed the linkage of OpenSSL
- Removed Boost automatic link (By manually linking boost libraries, there is no need to tell boost to do automatic link)
- Added WIN32_WINNT definition targeting Windows 7
