### PR TITLE
Windows + MSVC compatibility build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,18 @@ add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
-find_package(Boost 1.71.0 REQUIRED system)
+find_package(Boost 1.71.0 REQUIRED system date_time)
 find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
+
+if (WIN32)
+	add_definitions(-D_WIN32_WINNT=0x0601) # Windows 7
+endif()
+
+if (MSVC)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj")
+endif()
 
 INCLUDE_DIRECTORIES(
         ${Boost_INCLUDE_DIRS}
@@ -36,6 +45,5 @@ TARGET_LINK_LIBRARIES(
         discordpp-rest-beast
         discordpp-websocket-beast
         Threads::Threads
-        crypto
-        ssl
+        ${OPENSSL_LIBRARIES}
 )


### PR DESCRIPTION
- WIN32_WINNT defined to target Windows 7 or greater
- Changed hardcoded OpenSSL libraries
- Fixes big object compilation with Microsoft Visual C++