### PR TITLE
Add docker file + Add environment variables as method to pass tokens

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+build/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-Dockerfile
-.dockerignore
-build/
-.git/
+# Just the bare essentials 
+**
+!lib/**
+!CMakeLists.txt
+!main.cc

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 Dockerfile
-build/*
+.dockerignore
+build/
+.git/

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ token.dat
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/dictionaries
-.vscode/
 
 # Sensitive or high-churn files:
 .idea/**/dataSources/
@@ -96,3 +95,19 @@ fabric.properties
 .idea/
 
 # End of https://www.gitignore.io/api/jetbrains+all
+
+# Created by https://www.gitignore.io/api/visualstudiocode
+# Edit at https://www.gitignore.io/?templates=visualstudiocode
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+# End of https://www.gitignore.io/api/visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ token.dat
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/dictionaries
+.vscode/
 
 # Sensitive or high-churn files:
 .idea/**/dataSources/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use -e ECHO_BOT_TOKEN="Bot exampletoken" as an environment variable when running
-FROM ubuntu:20.04 AS setup
+FROM ubuntu:20.04 AS build
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y \
     libboost-all-dev \
@@ -9,8 +9,6 @@ RUN apt update && apt install -y \
     libcrypto++-dev \
     libcurl4-openssl-dev \
 && rm -rf /var/lib/apt/lists/*
-
-FROM setup AS build
 WORKDIR /echo-bot
 COPY . .
 RUN mkdir build && cd build && cmake .. && make

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
+# Use -e ECHO_BOT_TOKEN="Bot exampletoken" as an environment variable when running
 FROM lballabio/boost:1.73.0-focal
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt upgrade -y && apt install -y git cmake build-essential libssl-dev libcrypto++-dev libcurl4-openssl-dev
+RUN apt update && apt install -y git cmake build-essential libssl-dev libcrypto++-dev libcurl4-openssl-dev
 WORKDIR /echo-bot
 COPY . .
 RUN git submodule update --init --recursive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use -e ECHO_BOT_TOKEN="Bot exampletoken" as an environment variable when running
+# Use -e BOT_TOKEN="Bot exampletoken" as an environment variable when running
 FROM ubuntu:20.04 AS build
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y \
@@ -7,12 +7,12 @@ RUN apt update && apt install -y \
     build-essential \
     libssl-dev \
 && rm -rf /var/lib/apt/lists/*
-WORKDIR /echo-bot
+WORKDIR /echo_bot
 COPY . .
 RUN mkdir build && cd build && cmake .. && make
 
 FROM alpine:latest
 RUN apk --no-cache add libgcc libstdc++ libc6-compat
-WORKDIR /echo-bot
-COPY --from=build /echo-bot/build/echo_bot .
+WORKDIR /echo_bot
+COPY --from=build /echo_bot/build/echo_bot .
 CMD ["./echo_bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM lballabio/boost:1.73.0-focal
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt upgrade -y && apt install -y git cmake build-essential libssl-dev libcrypto++-dev libcurl4-openssl-dev
+WORKDIR /echo-bot
+COPY . .
+RUN git submodule update --init --recursive
+RUN mkdir build && cd build && cmake .. && make
+CMD ["./build/echo_bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ RUN apt update && apt install -y \
     cmake \
     build-essential \
     libssl-dev \
-    libcrypto++-dev \
-    libcurl4-openssl-dev \
 && rm -rf /var/lib/apt/lists/*
 WORKDIR /echo-bot
 COPY . .

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Run `git clone --recursive https://github.com/discordpp/echo-bot.git` in your de
 ### Build your Bot
  1. Create a `build` directory (folder) with `mkdir build`
  2. Enter the folder with `cd build`
- 3. Go back to your Application's 'bot' page from before, and copy the token. Run `echo Bot [token] > token.dat`, replacing the brackets and the word token
+ 3. Go back to your Application's 'bot' page from before, and copy the token. Run `echo Bot [token] > token.dat`, replacing `[token]` with your bot's token.  Alternatively, you can set the `ECHO_BOT_TOKEN` environment variable to `Bot [token]`.
  4. Build the makefiles with `cmake ../`
  5. Build the bot with `make`
  6. Run the bot with `./echo_bot`

--- a/main.cc
+++ b/main.cc
@@ -146,13 +146,13 @@ int main(){
 
 std::string getToken() {
 	std::string token;
-	
+
 		/*
 			First attempt to read the token from the BOT_TOKEN environment variable.
 		*/
 	char const* env = std::getenv("BOT_TOKEN");
 	if(env != nullptr) {
-		token = (std::string) env;
+		token = std::string(env);
 	} else {
 		/*/
 		 * Read token from token file.

--- a/main.cc
+++ b/main.cc
@@ -28,10 +28,10 @@ int main(){
 	std::cout << "Starting bot...\n\n";
 
 	std::string token = getToken();
-	if(token == "") {
+	if(token.empty()) {
 		std::cerr << "CRITICAL: "
 						<< "There is no valid way for Echo to obtain a token! Use one of the following ways:" << std::endl
-						<< "(1) Fill the ECHO_BOT_TOKEN environment variable with the token (e.g. 'Bot 123456abcdef')." << std::endl
+						<< "(1) Fill the BOT_TOKEN environment variable with the token (e.g. 'Bot 123456abcdef')." << std::endl
 						<< "(2) Copy the example `token.eg.dat` as `token.dat` and write your own token to it.\n";
 			exit(1);
 	}
@@ -148,9 +148,9 @@ std::string getToken() {
 	std::string token;
 	
 		/*
-			First attempt to read the token from the ECHO_BOT_TOKEN environment variable.
+			First attempt to read the token from the BOT_TOKEN environment variable.
 		*/
-	char const* env = std::getenv("ECHO_BOT_TOKEN");
+	char const* env = std::getenv("BOT_TOKEN");
 	if(env != nullptr) {
 		token = (std::string) env;
 	} else {

--- a/main.cc
+++ b/main.cc
@@ -14,6 +14,7 @@ using json = nlohmann::json;
 namespace dpp = discordpp;
 using DppBot = dpp::PluginResponder<dpp::PluginOverload<dpp::WebsocketBeast<dpp::RestBeast<dpp::Bot> > > >;
 
+std::string getToken();
 std::istream &safeGetline(std::istream &is, std::string &t);
 
 void filter(std::string &target, const std::string &pattern);
@@ -26,22 +27,13 @@ int main(){
 
 	std::cout << "Starting bot...\n\n";
 
-	/*/
-	 * Read token from token file.
-	 * Tokens are required to communicate with Discord, and hardcoding tokens is a bad idea.
-	 * If your bot is open source, make sure it's ignore by git in your .gitignore file.
-	/*/
-	std::string token;
-	{
-		std::ifstream tokenFile("token.dat");
-		if(!tokenFile){
-			std::cerr << "CRITICAL: "
-			          << "There is no valid way for Echo to obtain a token! "
-			          << "Copy the example `token.eg.dat` as `token.dat` to make one.\n";
+	std::string token = getToken();
+	if(token == "") {
+		std::cerr << "CRITICAL: "
+						<< "There is no valid way for Echo to obtain a token! Use one of the following ways:" << std::endl
+						<< "(1) Fill the ECHO_BOT_TOKEN environment variable with the token (e.g. 'Bot 123456abcdef')." << std::endl
+						<< "(2) Copy the example `token.eg.dat` as `token.dat` and write your own token to it.\n";
 			exit(1);
-		}
-		safeGetline(tokenFile, token);
-		tokenFile.close();
 	}
 
 	// Create Bot object
@@ -150,6 +142,31 @@ int main(){
 	bot->run();
 
 	return 0;
+}
+
+std::string getToken() {
+	std::string token;
+	
+		/*
+			First attempt to read the token from the ECHO_BOT_TOKEN environment variable.
+		*/
+	char const* env = std::getenv("ECHO_BOT_TOKEN");
+	if(env != nullptr) {
+		token = (std::string) env;
+	} else {
+		/*/
+		 * Read token from token file.
+		 * Tokens are required to communicate with Discord, and hardcoding tokens is a bad idea.
+		 * If your bot is open source, make sure it's ignore by git in your .gitignore file.
+		/*/
+		std::ifstream tokenFile("token.dat");
+		if(!tokenFile){
+			return "";
+		}
+		safeGetline(tokenFile, token);
+		tokenFile.close();
+	}
+	return token;
 }
 
 /*/


### PR DESCRIPTION
This PR is in two parts:

1. A Dockerfile that allows for a build result (alpine image of ~19MB). To run it, try:
`docker image build -t echo-bot .` followed by `docker run -e ECHO_BOT_TOKEN="Bot <mytoken>" echo-bot`
2. Being able to use the environment token to start up the bot. Running the bot from a token file also still works (though this is currently not supported in the Docker setup)