### PR TITLE
Fixed wall of warnings using MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,9 @@ if (WIN32)
 endif()
 
 if (MSVC)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /wd4250 /wd4244")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj")
+        add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 INCLUDE_DIRECTORIES(


### PR DESCRIPTION
MSVC doesn't appreciate inheritance, without disabling inheritance warnings you get 25+ of them out of the box.