### PR TITLE
Fixes compilation for vs2022

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,13 +34,13 @@ if (WIN32)
 endif ()
 
 if (MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /wd4250 /wd4244")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /wd4250 /wd4244 /Zc:preprocessor")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj")
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-endif ()
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=address -fno-omit-frame-pointer")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
+    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=address -fno-omit-frame-pointer")
+endif()
 
 TARGET_LINK_LIBRARIES(
         ${PROJECT_NAME}

--- a/main.cc
+++ b/main.cc
@@ -154,7 +154,7 @@ int main() {
              // Scan through mentions in the message for self
              bool mentioned = false;
              for (const json &mention : msg["mentions"]) {
-                 mentioned = mentioned or mention["id"] == self["id"];
+                 mentioned = mentioned || mention["id"] == self["id"];
              }
              if (mentioned) {
                  // Identify and remove mentions of self from the message


### PR DESCRIPTION
Changes done:
- Changes or to ||
- Adds macro to let discordp builds on vs2022
- Avoid setting GCC macros on msvc

Would need https://github.com/DiscordPP/discordpp/pull/36 as well to correctly build echo bot